### PR TITLE
RAM boot should reset and halt before RAM writes

### DIFF
--- a/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/run/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use probe_rs::debug::{DebugInfo, DebugRegisters};
-use probe_rs::flashing::{FileDownloadError, FormatKind};
+use probe_rs::flashing::{FileDownloadError, FlashCommitInfo, FormatKind};
 use probe_rs::{
     exception_handler_for_core,
     probe::list::Lister,
@@ -153,7 +153,7 @@ impl Cmd {
                 tracing::debug!("RTT ScanRegion::Exact address is within region to be flashed")
             }
 
-            let flash_info = run_flash_download(
+            let flash_commit_info = run_flash_download(
                 &mut session,
                 &self.shared_options.path,
                 &self.shared_options.download_options,
@@ -162,13 +162,17 @@ impl Cmd {
                 self.shared_options.chip_erase,
             )?;
 
-            if flash_info.entry_point_in_ram {
-                session.prepare_running_on_ram(flash_info.entry_point.unwrap())?;
-            } else {
-                // reset the core to leave it in a consistent state after flashing
-                session
-                    .core(core_id)?
-                    .reset_and_halt(Duration::from_millis(100))?;
+            match flash_commit_info {
+                FlashCommitInfo::BootFromRam { entry_point } => {
+                    // core should be already reset and halt by this point.
+                    session.prepare_running_on_ram(entry_point)?;
+                }
+                FlashCommitInfo::Other => {
+                    // reset the core to leave it in a consistent state after flashing
+                    session
+                        .core(core_id)?
+                        .reset_and_halt(Duration::from_millis(100))?;
+                }
             }
         }
 

--- a/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
+++ b/probe-rs-tools/src/bin/probe-rs/cmd/verify.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use probe_rs::flashing::{FlashCommitInfo, FlashError};
+use probe_rs::flashing::FlashError;
 use probe_rs::probe::list::Lister;
 
 use crate::util::common_options::ProbeOptions;
@@ -24,9 +24,8 @@ impl Cmd {
         let (mut session, _probe_options) = self.probe_options.simple_attach(lister)?;
 
         let loader = build_loader(&mut session, &self.path, self.format_options, None)?;
-        let mut commit_info = FlashCommitInfo::default();
 
-        match loader.verify(&mut session, &mut commit_info) {
+        match loader.verify(&mut session) {
             Ok(()) => {
                 println!("Verification successful")
             }

--- a/probe-rs/src/architecture/arm/sequences.rs
+++ b/probe-rs/src/architecture/arm/sequences.rs
@@ -993,6 +993,8 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
 
     /// This ARM sequence is called if an image was flashed to RAM directly.
     /// It will perform the necessary preparation to run that image.
+    ///
+    /// Core should be already `reset_and_halt`ed right before this call.
     fn prepare_running_on_ram(
         &self,
         vector_table_offset: u64,
@@ -1018,8 +1020,6 @@ pub trait ArmDebugSequence: Send + Sync + Debug {
             CoreType::Armv6m | CoreType::Armv7m | CoreType::Armv7em | CoreType::Armv8m => {
                 tracing::debug!("RAM flash start for Cortex-M single core target");
                 let mut core = session.core(0)?;
-                // Ensure the core is halted in any case.
-                core.halt(Duration::from_millis(100))?;
                 // See ARMv7-M Architecture Reference Manual Chapter B1.5 for more details. The
                 // process appears to be the same for the other Cortex-M architectures as well.
                 let vtor = Vtor(vector_table_offset as u32);

--- a/probe-rs/src/flashing/loader.rs
+++ b/probe-rs/src/flashing/loader.rs
@@ -287,13 +287,17 @@ impl ImageLoader for IdfLoader {
     }
 }
 
-/// Information about the flashing process result.
+/// Status of the successful [`FlashLoader::commit`] operation
 #[derive(Debug, Default)]
-pub struct FlashCommitInfo {
-    /// This will be [true] if the entry point of the application is inside a RAM region.
-    pub entry_point_in_ram: bool,
-    /// This will have hold the address of the entry point if the entry point is in RAM.
-    pub entry_point: Option<u64>,
+pub enum FlashCommitInfo {
+    /// Relevant for the [`FlashLoader::commit`] caller in order to prepare the chip for booting from RAM
+    BootFromRam {
+        /// Entry point of the program loaded to RAM
+        entry_point: u64,
+    },
+    /// Core will not be booting from RAM (dry run, boot from flash or just commiting some memory etc.)
+    #[default]
+    Other,
 }
 
 /// `FlashLoader` is a struct which manages the flashing of any chunks of data onto any sections of flash.
@@ -413,12 +417,8 @@ impl FlashLoader {
     }
 
     /// Verifies data on the device.
-    pub fn verify(
-        &self,
-        session: &mut Session,
-        commit_info: &mut FlashCommitInfo,
-    ) -> Result<(), FlashError> {
-        let algos = self.prepare_plan(session, commit_info)?;
+    pub fn verify(&self, session: &mut Session) -> Result<(), FlashError> {
+        let algos = self.prepare_plan(session)?;
 
         let progress = FlashProgress::new(|_| {});
 
@@ -457,7 +457,7 @@ impl FlashLoader {
         tracing::debug!("Committing FlashLoader!");
         let mut commit_info = FlashCommitInfo::default();
 
-        let algos = self.prepare_plan(session, &mut commit_info)?;
+        let algos = self.prepare_plan(session)?;
 
         if options.dry_run {
             tracing::info!("Skipping programming, dry run!");
@@ -581,9 +581,22 @@ impl FlashLoader {
             // If this is a RAM only flash, the core might still be running. This can be
             // problematic if the instruction RAM is flashed while an application is running, so
             // the core is halted here in any case.
+            //
+            // Additionally, if entry point is detected in the given RAM region, core should be
+            // reset & halted
             if !core.core_halted().map_err(FlashError::Core)? {
-                core.halt(Duration::from_millis(500))
-                    .map_err(FlashError::Core)?;
+                match self.entry_point {
+                    Some(entry_point) if region.range.contains(&entry_point) => {
+                        commit_info = FlashCommitInfo::BootFromRam { entry_point };
+                        tracing::debug!("     -- action: core is not halted and entry point in RAM that is being written, resetting and halting");
+                        core.reset_and_halt(Duration::from_millis(500))
+                    }
+                    _ => {
+                        tracing::debug!("     -- action: core is not halted and RAM is being written, halting");
+                        core.halt(Duration::from_millis(500))
+                    },
+                }
+                .map_err(FlashError::Core)?;
             }
 
             let mut some = false;
@@ -614,7 +627,6 @@ impl FlashLoader {
     fn prepare_plan(
         &self,
         session: &mut Session,
-        commit_info: &mut FlashCommitInfo,
     ) -> Result<HashMap<(String, usize), Vec<NvmRegion>>, FlashError> {
         tracing::debug!("Contents of builder:");
         for (&address, data) in &self.builder.data {
@@ -624,14 +636,6 @@ impl FlashLoader {
                 address + data.len() as u64,
                 data.len()
             );
-        }
-        if let Some(entry_point) = self.entry_point {
-            if let Some(MemoryRegion::Ram(_)) =
-                Self::get_region_for_address(&self.memory_map, entry_point)
-            {
-                commit_info.entry_point_in_ram = true;
-                commit_info.entry_point = self.entry_point;
-            }
         }
 
         tracing::debug!("Flash algorithms:");


### PR DESCRIPTION
In certain chips (eg. NXP IMXRT118x) availability of RAM memory regions depends on runtime configuration. It is better to reset and halt before we do any RAM writes to guarantee some consistent, default state.

- use an enum instead of bool + Option
- avoid adding even more boolean logic